### PR TITLE
Make error messages appear

### DIFF
--- a/src/BabDev/Transifex/TransifexObject.php
+++ b/src/BabDev/Transifex/TransifexObject.php
@@ -98,6 +98,10 @@ abstract class TransifexObject
 			{
 				$message = $error->message;
 			}
+			elseif ($response->body)
+			{
+				$message = $response->body;
+			}
 			else
 			{
 				$message = 'No error message was returned from the server.';


### PR DESCRIPTION
Transifex doesn't seem to return a JSON string when an error occurs .
