### PR TITLE
Add the ?details fragment when retrieving language details

### DIFF
--- a/docs/classes/Languages.md
+++ b/docs/classes/Languages.md
@@ -81,6 +81,16 @@ use BabDev\Transifex\Transifex;
 $apiResponse = (new Transifex())->get('languages')->getLanguage('my-project', 'en-US');
 ```
 
+This method also has one optional parameter to add the `?details` fragment:
+
+* True to add the `?details` fragment (bool)
+
+```php
+use BabDev\Transifex\Transifex;
+
+$apiResponse = (new Transifex())->get('languages')->getLanguage('my-project', 'en-US', true);
+```
+
 ### Get the project's languages
 
 To get the project's languages, call the `Languages::getLanguages()` method.

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -118,14 +118,17 @@ class Languages extends TransifexObject
      *
      * @param string $project  The project to retrieve details for
      * @param string $langCode The language code to retrieve details for
+     * @param bool   $details  True to add the ?details fragment
      *
      * @return ResponseInterface
      */
-    public function getLanguage(string $project, string $langCode) : ResponseInterface
+    public function getLanguage(string $project, string $langCode, bool $details = false) : ResponseInterface
     {
+        $flag = $details ? '?details' : '';
+
         return $this->client->request(
             'GET',
-            new Uri("/api/2/project/$project/language/$langCode/"),
+            new Uri("/api/2/project/$project/language/$langCode/$flag"),
             ['auth' => $this->getAuthData()]
         );
     }

--- a/src/Languages.php
+++ b/src/Languages.php
@@ -124,11 +124,15 @@ class Languages extends TransifexObject
      */
     public function getLanguage(string $project, string $langCode, bool $details = false) : ResponseInterface
     {
-        $flag = $details ? '?details' : '';
+        $uri = new Uri("/api/2/project/$project/language/$langCode/");
+
+        if ($details) {
+            $uri = Uri::withQueryValue($uri, 'details', null);
+        }
 
         return $this->client->request(
             'GET',
-            new Uri("/api/2/project/$project/language/$langCode/$flag"),
+            $uri,
             ['auth' => $this->getAuthData()]
         );
     }

--- a/tests/LanguagesTest.php
+++ b/tests/LanguagesTest.php
@@ -170,6 +170,23 @@ class LanguagesTest extends TransifexTestCase
     }
 
     /**
+     * @testdox getLanguage() returns a Response object on a successful API connection
+     *
+     * @covers  \BabDev\Transifex\Languages::getLanguage
+     * @covers  \BabDev\Transifex\TransifexObject::getAuthData
+     *
+     * @uses    \BabDev\Transifex\TransifexObject
+     */
+    public function testGetLanguageWithDetails()
+    {
+        $this->prepareSuccessTest();
+
+        (new Languages($this->options, $this->client))->getLanguage('babdev-transifex', 'en_US', true);
+
+        $this->validateSuccessTest('/api/2/project/babdev-transifex/language/en_US/?details');
+    }
+
+    /**
      * @testdox getLanguage() throws a ServerException on a failed API connection
      *
      * @covers  \BabDev\Transifex\Languages::getLanguage

--- a/tests/LanguagesTest.php
+++ b/tests/LanguagesTest.php
@@ -183,7 +183,16 @@ class LanguagesTest extends TransifexTestCase
 
         (new Languages($this->options, $this->client))->getLanguage('babdev-transifex', 'en_US', true);
 
-        $this->validateSuccessTest('/api/2/project/babdev-transifex/language/en_US/?details');
+        $this->validateSuccessTest('/api/2/project/babdev-transifex/language/en_US/');
+
+        /** @var \Psr\Http\Message\RequestInterface $request */
+        $request = $this->historyContainer[0]['request'];
+
+        $this->assertSame(
+            'details',
+            $request->getUri()->getQuery(),
+            'The API request did not include the expected query string.'
+        );
     }
 
     /**


### PR DESCRIPTION
The [Transifex API](https://docs.transifex.com/api/languages#managing-a-language-instance) allows to add the `?details` fragment when retrieving languages to get additional information such as the translated segments. This PR adds a third parameter to the `getLanguage()` method, which optionally adds the `?details` fragment to the request URL.